### PR TITLE
Fix a race condition on notifs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 
 
 # misc
-.vscode
 .DS_Store
 .env.local
 .env.development.local

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 
 # misc
+.vscode
 .DS_Store
 .env.local
 .env.development.local
@@ -20,4 +21,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 dist/
-.key.config.js 
+.key.config.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/src/background/service/notification.ts
+++ b/src/background/service/notification.ts
@@ -68,16 +68,12 @@ class NotificationService extends Events {
 
   // currently it only support one approval at the same time
   requestApproval = async (data, winProps?): Promise<any> => {
-    // if the request comes into while user approving
-    if (this.approval) {
-      throw ethErrors.provider.userRejectedRequest('please request after current approval resolve');
-    }
-
     // if (preferenceService.getPopupOpen()) {
     //   this.approval = null;
     //   throw ethErrors.provider.userRejectedRequest('please request after user close current popup');
     // }
 
+    // We will just override the existing open approval with the new one coming in
     return new Promise((resolve, reject) => {
       this.approval = {
         data,


### PR DESCRIPTION

# Context

```
{code: 4001, message: 'please request after current approval resolve'}
```

It seems like a race condition, and it happens so often that the wallet is not usable - that the approval window is not openning fast enough, and user cannot sign any psbt.

# Proposal

Remove the check of `if (this.approval)` and always override the exisiting approval with new approvals, which is probably what the users want.