### PR TITLE
Switch block explorer to mempool

### DIFF
--- a/src/ui/components/AddressDetailPopover/index.tsx
+++ b/src/ui/components/AddressDetailPopover/index.tsx
@@ -1,4 +1,4 @@
-import { useBlockstreamUrl } from '@/ui/state/settings/hooks';
+import { useMempoolUrl } from '@/ui/state/settings/hooks';
 import { copyToClipboard, shortAddress } from '@/ui/utils';
 
 import { useTools } from '../ActionComponent';
@@ -11,7 +11,7 @@ import { Text } from '../Text';
 
 export const AddressDetailPopover = ({ address, onClose }: { address: string; onClose: () => void }) => {
   const tools = useTools();
-  const blockstreamUrl = useBlockstreamUrl();
+  const mempoolUrl = useMempoolUrl();
   return (
     <Popover onClose={onClose}>
       <Column>
@@ -37,7 +37,7 @@ export const AddressDetailPopover = ({ address, onClose }: { address: string; on
         <Row
           justifyCenter
           onClick={() => {
-            window.open(`${blockstreamUrl}/address/${address}`);
+            window.open(`${mempoolUrl}/address/${address}`);
           }}>
           <Icon icon="eye" color="textDim" />
           <Text preset="regular-bold" text="View on Block Explorer" color="textDim" />

--- a/src/ui/pages/Wallet/HistoryScreen/index.tsx
+++ b/src/ui/pages/Wallet/HistoryScreen/index.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { Layout, Content, Icon, Header, Text, Row, Column, Card } from '@/ui/components';
 import { useTools } from '@/ui/components/ActionComponent';
 import { useAccountAddress, useFetchHistoryCallback, useHistory } from '@/ui/state/accounts/hooks';
-import { useBlockstreamUrl } from '@/ui/state/settings/hooks';
+import { useMempoolUrl } from '@/ui/state/settings/hooks';
 import { shortAddress } from '@/ui/utils';
 import { ClockCircleFilled } from '@ant-design/icons';
 
@@ -27,7 +27,7 @@ interface MyItemProps {
 
 const MyItem: React.ForwardRefRenderFunction<any, MyItemProps> = ({ group, index }, ref) => {
   const address = useAccountAddress();
-  const blockstreamUrl = useBlockstreamUrl();
+  const mempoolUrl = useMempoolUrl();
   if (group.index == -1) {
     return (
       <Column>
@@ -35,7 +35,7 @@ const MyItem: React.ForwardRefRenderFunction<any, MyItemProps> = ({ group, index
         <Row
           justifyCenter
           onClick={() => {
-            window.open(`${blockstreamUrl}/address/${address}`);
+            window.open(`${mempoolUrl}/address/${address}`);
           }}>
           <Icon icon="eye" color="textDim" />
           <Text preset="regular-bold" text="View on Block Explorer" color="textDim" />

--- a/src/ui/pages/Wallet/TxSuccessScreen.tsx
+++ b/src/ui/pages/Wallet/TxSuccessScreen.tsx
@@ -1,6 +1,6 @@
 import { Layout, Header, Content, Icon, Text, Column, Footer, Button, Row } from '@/ui/components';
 import { useNavigate } from '@/ui/pages/MainRoute';
-import { useBlockstreamUrl } from '@/ui/state/settings/hooks';
+import { useMempoolUrl } from '@/ui/state/settings/hooks';
 import { spacing } from '@/ui/theme/spacing';
 import { useLocationState } from '@/ui/utils';
 
@@ -11,7 +11,7 @@ interface LocationState {
 export default function TxSuccessScreen() {
   const { txid } = useLocationState<LocationState>();
   const navigate = useNavigate();
-  const blockstreamUrl = useBlockstreamUrl();
+  const mempoolUrl = useMempoolUrl();
 
   return (
     <Layout>
@@ -29,7 +29,7 @@ export default function TxSuccessScreen() {
           <Row
             justifyCenter
             onClick={() => {
-              window.open(`${blockstreamUrl}/tx/${txid}`);
+              window.open(`${mempoolUrl}/tx/${txid}`);
             }}>
             <Icon icon="eye" color="textDim" />
             <Text preset="regular-bold" text="View on Block Explorer" color="textDim" />

--- a/src/ui/state/settings/hooks.ts
+++ b/src/ui/state/settings/hooks.ts
@@ -66,17 +66,17 @@ export function useChangeNetworkTypeCallback() {
 export function useBlockstreamUrl() {
   const networkType = useNetworkType();
   if (networkType === NetworkType.MAINNET) {
-    return 'https://blockstream.info';
+    return 'https://mempool.space';
   } else {
-    return 'https://blockstream.info/testnet';
+    return 'https://mempool.space/testnet';
   }
 }
 
 export function useTxIdUrl(txid: string) {
   const networkType = useNetworkType();
   if (networkType === NetworkType.MAINNET) {
-    return `https://blockstream.info/tx/${txid}`;
+    return `https://mempool.space/tx/${txid}`;
   } else {
-    return `https://blockstream.info/testnet/tx/${txid}`;
+    return `https://mempool.space/testnet/tx/${txid}`;
   }
 }

--- a/src/ui/state/settings/hooks.ts
+++ b/src/ui/state/settings/hooks.ts
@@ -63,7 +63,7 @@ export function useChangeNetworkTypeCallback() {
   );
 }
 
-export function useBlockstreamUrl() {
+export function useMempoolUrl() {
   const networkType = useNetworkType();
   if (networkType === NetworkType.MAINNET) {
     return 'https://mempool.space';


### PR DESCRIPTION
mempool.space is an actively-maintained, widely-used, and constantly-improving block explorer that many people prefer to use over blockstream.info.

Here's a Unisat tutorial someone uploaded yesterday...they're constantly switching to mempool.space:
https://www.youtube.com/watch?v=XftBkRZ9jqk

Mempool also helps users determine fees, which Blockstream doesn't do at all.