### PR TITLE
Support specifying toSignInputs in signPsbt options

### DIFF
--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -367,7 +367,8 @@ export class WalletController extends BaseController {
   };
 
   signPsbt = async (psbt: bitcoin.Psbt, options?: any) => {
-    const toSignInputs: ToSignInput[] = this._getToSignInputs(psbt, options?.toSignInputs);
+    const userToSignInputs = Array.isArray(options?.toSignInputs) ? options!.toSignInputs : undefined;
+    const toSignInputs: ToSignInput[] = this._getToSignInputs(psbt, userToSignInputs);
 
     psbt = await keyringService.signTransaction(_keyring, psbt, toSignInputs);
     if (options && options.autoFinalized == false) {


### PR DESCRIPTION
This is an effort to solve for the issue raised at https://github.com/unisat-wallet/extension/issues/86.

This allows user to specify toSignInputs option for signPsbt method to allow overriding the default simple logic for determining each inputs require signature. The following schema for options is as follows:

```typescript
interface BaseUserToSignInput {
  index: number;
  sighashTypes: number[];
}

interface AddressUserToSignInput extends BaseUserToSignInput {
  address: string;
}

interface PublicKeyUserToSignInput extends BaseUserToSignInput {
  publicKey: string;
}

type UserToSignInput = AddressUserToSignInput | PublicKeyUserToSignInput;

interface SignPsbtOptions {
  autoFinalized: boolean;
  toSignInputs: UserToSignInput[];
}
```

Basically `index` and `sighashTypes` are required, and one of `address` or `publicKey` is needed as well.