### PR TITLE
docs: update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ UniSat Wallet - the first open-source browser extension wallet for Ordinals on b
 
 ## How to build
 
-- Install [Node.js](https://nodejs.org) version 14
+- Install [Node.js](https://nodejs.org) version 16
 - Install [Yarn](https://yarnpkg.com/en/docs/install)
 - Install dependencies: `yarn`
 - Build the project to the `./dist/` folder with `yarn build:firefox` for Firefox


### PR DESCRIPTION
The README seems to be outdated as installing deps causes the engine incompatibility error:

```
error @noble/hashes@1.3.1: The engine "node" is incompatible with this module. Expected version ">= 16". Got "14.21.3"
```

If it's intentional to keep node v14 we can try downgrading to @noble/hashes v1.3.0, which doesn't state engine requirement.